### PR TITLE
Added new productId and switched to HEX for VID and PID.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class LEDController {
     this.keyboard = (function () {
       const keyboard_info = HID.devices().find((item) => {
         return (
-          item.vendorId === 1241 &&
+          item.vendorId === 0x04d9 &&
           item.interface === 1 &&
           LEDController.known_pids.includes(item.productId)
         );
@@ -128,7 +128,7 @@ class LEDController {
 
 //Static mapping
 const mcu_address = 65;
-LEDController.known_pids = [41618, 32777, 41619];
+LEDController.known_pids = [0x8008, 0x8009, 0xa292, 0xa293];
 LEDController.AnnePro2_layout = [
   { key: 'esc', matrix_id: 0 },
   { key: '1', matrix_id: 1 },


### PR DESCRIPTION
Hi! I just happened to come across these rules in "/etc/udev/rules.d/obinskit-kdb.rules".

\# For ANNE PRO 2
SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="8008",MODE="0666", GROUP="plugdev"
KERNEL=="hidraw*", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="8008",MODE="0666", GROUP="plugdev"

SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="8009",MODE="0666", GROUP="plugdev"
KERNEL=="hidraw*", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="8009",MODE="0666", GROUP="plugdev"

SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="a292",MODE="0666", GROUP="plugdev"
KERNEL=="hidraw*", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="a292",MODE="0666", GROUP="plugdev"

SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="a293",MODE="0666", GROUP="plugdev"
KERNEL=="hidraw*", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="a293",MODE="0666", GROUP="plugdev"

\## For ANNE PRO
SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5710",MODE="0666", GROUP="plugdev"
KERNEL=="hidraw*", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5710",MODE="0666", GROUP="plugdev"
´
So I added another extra PID, and converted the already existing PIDs to Hex, it's kind of a standard i think.