### PR TITLE
Update 'node-hid' dependency to version 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Anne Pro 2 RGB control through Node.js",
   "main": "index.js",
   "dependencies": {
-    "node-hid": "^1.2.0"
+    "node-hid": "^2.1.1"
   },
   "devDependencies": {
     "eslint": "^7.0.0",


### PR DESCRIPTION
I get an error when installing Annemone using `npm install -g annemone`. Updating `node-hid` module to a newer version seems to fix the issue.
<details>
  <summary>Error message</summary>

  ```
npm ERR! code 7
npm ERR! path /home/swalrus/.npm-global/lib/node_modules/annemone/node_modules/node-hid
npm ERR! command failed
npm ERR! command sh -c prebuild-install || node-gyp rebuild
npm ERR! prebuild-install WARN install No prebuilt binaries found (target=16.11.1 runtime=node arch=x64 libc= platform=linux)
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@16.11.1 | linux | x64
npm ERR! gyp info find Python using Python version 3.9.7 found at "/usr/bin/python3"
npm ERR! gyp ERR! UNCAUGHT EXCEPTION
npm ERR! gyp ERR! stack Error: Cannot find module 'request'
npm ERR! gyp ERR! stack Require stack:
npm ERR! gyp ERR! stack - /usr/lib/node_modules/npm/node_modules/node-gyp/lib/install.js
npm ERR! gyp ERR! stack - /usr/lib/node_modules/npm/node_modules/node-gyp/lib/node-gyp.js
npm ERR! gyp ERR! stack - /usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js
npm ERR! gyp ERR! stack     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
npm ERR! gyp ERR! stack     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
npm ERR! gyp ERR! stack     at Module.require (node:internal/modules/cjs/loader:1005:19)
npm ERR! gyp ERR! stack     at require (node:internal/modules/cjs/helpers:102:18)
npm ERR! gyp ERR! stack     at Object.<anonymous> (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/install.js:10:17)
npm ERR! gyp ERR! stack     at Module._compile (node:internal/modules/cjs/loader:1101:14)
npm ERR! gyp ERR! stack     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
npm ERR! gyp ERR! stack     at Module.load (node:internal/modules/cjs/loader:981:32)
npm ERR! gyp ERR! stack     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
npm ERR! gyp ERR! stack     at Module.require (node:internal/modules/cjs/loader:1005:19)
npm ERR! gyp ERR! System Linux 5.14.14-arch1-1
npm ERR! gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /home/swalrus/.npm-global/lib/node_modules/annemone/node_modules/node-hid
npm ERR! gyp ERR! node -v v16.11.1
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! Node-gyp failed to build your package.
npm ERR! gyp ERR! Try to update npm and/or node-gyp and if it does not help file an issue with the package author.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/swalrus/.npm/_logs/2021-10-28T13_46_29_649Z-debug.log
  ```
  
</details>